### PR TITLE
fix(error): use proper error for better logging

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -179,12 +179,9 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback) {
     request[method](options, function (err, response, body) {
       if (err || (response.statusCode > 210)) {
         if (typeof callback === 'function') {
-          callback(err || body, response)
+          callback(err || new Error(body), response)
         }
-        reject({
-          error: err || body,
-          response: response
-        })
+        reject(err || new Error(body))
       } else {
         if (typeof callback === 'function') {
           callback(null, response, body)


### PR DESCRIPTION
In the previous PR I kept the error signature of the callback for the promise.

Unfortunately that leads to unhelpful error messages in logs : 

```
Warning: a promise was rejected with a non-error: [object Object]
```

This PR allow for messages such as this : 

```
Unhandled rejection Error: Error: no auth mechanism defined
``` 

For anyone wondering, that message appears when the apikey/apisecret are not set properly ;)

For the sake of consistency I've changed the callback as well to return an error