### PR TITLE
Support proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ var Mailjet = require('node-mailjet').connect('api key', 'api secret');
 
 ```
 
+### Using an HTTP proxy
+
+If you need to send the email requests via a proxy, you can pass a third argument
+with the full proxy URL to `connect`, for instance:
+
+``` javascript
+var Mailjet = require('node-mailjet').connect('api key', 'api secret', process.env.https_proxy);
+```
+
+The proxy URL is passed directly to [superagent-proxy](https://github.com/TooTallNate/superagent-proxy).
+
 ### Get cosy with Mailjet
 
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ var Mailjet = require('node-mailjet').connect('api key', 'api secret');
 
 ```
 
-### Using an HTTP proxy
+Additional connection options may be passed as the third argument. These values are supported:
 
-If you need to send the email requests via a proxy, you can pass a third argument
-with the full proxy URL to `connect`, for instance:
+- `proxyUrl`: HTTP proxy URL to send the email requests through
+
+Example:
 
 ``` javascript
-var Mailjet = require('node-mailjet').connect('api key', 'api secret', process.env.https_proxy);
+var Mailjet = require('node-mailjet').connect('api key', 'api secret', {
+  proxyUrl: process.env.https_proxy
+});
 ```
 
 The proxy URL is passed directly to [superagent-proxy](https://github.com/TooTallNate/superagent-proxy).

--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -103,10 +103,9 @@ MailjetClient.connect = function (k, s, o) {
  *
  */
 MailjetClient.prototype.connect = function (apiKey, apiSecret, options) {
-  var options = options || {}
   this.apiKey = apiKey
   this.apiSecret = apiSecret
-  this.proxyUrl = options.proxyUrl
+  this.options = options || {}
   return this
 }
 
@@ -159,8 +158,8 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback) {
 
     .auth(this.apiKey, this.apiSecret)
 
-  if (this.proxyUrl) {
-    req = req.proxy(this.proxyUrl)
+  if (this.options.proxyUrl) {
+    req = req.proxy(this.options.proxyUrl)
   }
 
   const payload = method === 'post' || method === 'put' ? data : {}

--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -54,18 +54,18 @@ require('superagent-proxy')(request);
  *
  * @qpi_key (optional) {String} mailjet account api key
  * @api_secret (optional) {String} mailjet account api secret
- * @proxy_url (optional) {String} proxy URL for HTTPS requests
+ * @options (optional) {Object} additional connection options
  *
  * If you don't know what this is about, sign up to Mailjet at:
  * https://www.mailjet.com/
  */
-function MailjetClient (api_key, api_secret, proxy_url, testMode) {
+function MailjetClient (api_key, api_secret, options, testMode) {
   this.config = require('./config')
   this.testMode = testMode || false
   // To be updated according to the npm repo version
   this.version = version
   if (api_key && api_secret) {
-    this.connect(api_key, api_secret, proxy_url)
+    this.connect(api_key, api_secret, options)
   }
 }
 
@@ -85,11 +85,11 @@ MailjetClient.prototype.typeJson = function (body) {
  *
  * @k {String} mailjet qpi key
  * @s {String} mailjet api secret
- * @p {String} optional proxy URL
+ * @o {String} optional connection options
  *
  */
-MailjetClient.connect = function (k, s, p) {
-  return new MailjetClient().connect(k, s, p)
+MailjetClient.connect = function (k, s, o) {
+  return new MailjetClient().connect(k, s, o)
 }
 
 /*
@@ -99,13 +99,14 @@ MailjetClient.connect = function (k, s, p) {
  *
  * @apiKey {String}
  * @apiSecret {String}
- * @proxyUrl {String}
+ * @options {Object}
  *
  */
-MailjetClient.prototype.connect = function (apiKey, apiSecret, proxyUrl) {
+MailjetClient.prototype.connect = function (apiKey, apiSecret, options) {
+  var options = options || {}
   this.apiKey = apiKey
   this.apiSecret = apiSecret
-  this.proxyUrl = proxyUrl
+  this.proxyUrl = options.proxyUrl
   return this
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "bluebird": "^3.3.5",
     "json-bigint": "^0.2.0",
     "qs": "^4.0.0",
-    "superagent": "^2.0.0"
+    "superagent": "^2.0.0",
+    "superagent-proxy": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",

--- a/test/test.js
+++ b/test/test.js
@@ -36,18 +36,17 @@ describe('Basic Usage', function () {
     })
 
     it('creates an instance of the client with options', function () {
-      var proxyUrl = 'http://localhost:3128'
-      var expectedMembers = { apiKey: API_KEY, apiSecret: API_SECRET, proxyUrl: proxyUrl }
+      var options = { proxyUrl: 'http://localhost:3128' }
 
-      var connectionType1 = new Mailjet(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
-      var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
-      var connectionType3 = Mailjet.connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+      var connectionType1 = new Mailjet(API_KEY, API_SECRET, options)
+      var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, options)
+      var connectionType3 = Mailjet.connect(API_KEY, API_SECRET, options)
 
       var connections = [connectionType1, connectionType2, connectionType3]
       connections.forEach(function (connection) {
         expect(connection).to.have.property('apiKey', API_KEY)
         expect(connection).to.have.property('apiSecret', API_SECRET)
-        expect(connection.options).to.have.property('proxyUrl', proxyUrl)
+        expect(connection.options).to.have.property('proxyUrl', options.proxyUrl)
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,22 @@ describe('Basic Usage', function () {
       expect('' + connectionType2.apiKey + connectionType2.apiSecret).to.equal('' + API_KEY + API_SECRET)
       expect('' + connectionType3.apiKey + connectionType3.apiSecret).to.equal('' + API_KEY + API_SECRET)
     })
+
+    it('creates an instance of the client with options', function () {
+      var proxyUrl = 'http://localhost:3128'
+      var expectedMembers = { apiKey: API_KEY, apiSecret: API_SECRET, proxyUrl: proxyUrl }
+
+      var connectionType1 = new Mailjet(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+      var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+      var connectionType3 = Mailjet.connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+
+      var connections = [connectionType1, connectionType2, connectionType3]
+      connections.forEach(function (connection) {
+        expect(connection).to.have.property('apiKey', API_KEY)
+        expect(connection).to.have.property('apiSecret', API_SECRET)
+        expect(connection).to.have.property('proxyUrl', proxyUrl)
+      })
+    })
   })
 
   describe('method request', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,7 @@ describe('Basic Usage', function () {
       connections.forEach(function (connection) {
         expect(connection).to.have.property('apiKey', API_KEY)
         expect(connection).to.have.property('apiSecret', API_SECRET)
-        expect(connection).to.have.property('proxyUrl', proxyUrl)
+        expect(connection.options).to.have.property('proxyUrl', proxyUrl)
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -130,7 +130,7 @@ describe('Advanced API Calls', function () {
     }
   }
 
-  var client2 = new Mailjet(API_KEY, API_SECRET, true)
+  var client2 = new Mailjet(API_KEY, API_SECRET, null, true)
 
   const EXAMPLES_SET = [
     new Example(client2.get('contact')),


### PR DESCRIPTION
We run our application in an environment that requires you to use an HTTP proxy for email requests. This pull request allows you to specify a proxy URL as the third argument to the `connect` method.

There are no associated tests because the proxy URL is simply passed to the `proxy` method added by [superagent-proxy](https://github.com/TooTallNate/superagent-proxy), and I didn't know how to really test that. But I did run the existing tests to ensure nothing was broken.

I had to remove the `examples/sendmail/mailjet` submodule in order to install the package directly from GitHub (see the commit message). I figured it was not necessary since it is in the examples directory, but just let me know if you want to keep it there nonetheless, and I'll remove the commit. Having it there makes testing repository forks more difficult though.
