### PR TITLE
Return error on request timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,14 @@ var Mailjet = require('node-mailjet').connect('api key', 'api secret');
 Additional connection options may be passed as the third argument. These values are supported:
 
 - `proxyUrl`: HTTP proxy URL to send the email requests through
+- `timeout`: API request timeout in milliseconds
 
 Example:
 
 ``` javascript
 var Mailjet = require('node-mailjet').connect('api key', 'api secret', {
-  proxyUrl: process.env.https_proxy
+  proxyUrl: process.env.https_proxy,
+  timeout: 60000 // 1 minute
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ var Mailjet = require('node-mailjet').connect('api key', 'api secret');
 
 ```
 
+### Using an HTTP proxy
+
+If you need to send the email requests via a proxy, you can pass a third argument
+with the full proxy URL to `connect`, for instance:
+
+``` javascript
+var Mailjet = require('node-mailjet').connect('api key', 'api secret', process.env.https_proxy);
+```
+
+The proxy URL is passed directly to [superagent-proxy](https://github.com/TooTallNate/superagent-proxy).
+
 ### Get cosy with Mailjet
 
 

--- a/README.md
+++ b/README.md
@@ -45,13 +45,16 @@ var Mailjet = require('node-mailjet').connect('api key', 'api secret');
 
 ```
 
-### Using an HTTP proxy
+Additional connection options may be passed as the third argument. These values are supported:
 
-If you need to send the email requests via a proxy, you can pass a third argument
-with the full proxy URL to `connect`, for instance:
+- `proxyUrl`: HTTP proxy URL to send the email requests through
+
+Example:
 
 ``` javascript
-var Mailjet = require('node-mailjet').connect('api key', 'api secret', process.env.https_proxy);
+var Mailjet = require('node-mailjet').connect('api key', 'api secret', {
+  proxyUrl: process.env.https_proxy
+});
 ```
 
 The proxy URL is passed directly to [superagent-proxy](https://github.com/TooTallNate/superagent-proxy).

--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -161,6 +161,9 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback) {
   if (this.options.proxyUrl) {
     req = req.proxy(this.options.proxyUrl)
   }
+  if (this.options.timeout) {
+    req = req.timeout(this.options.timeout)
+  }
 
   const payload = method === 'post' || method === 'put' ? data : {}
 
@@ -195,11 +198,11 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback) {
         body = {}
       }
 
-      if (result && result.status && result.status > 210) {
+      if (err) {
         const error = new Error('Unsuccessful')
-        error.ErrorMessage = body.ErrorMessage || (result.res.statusMessage)
-        error.statusCode = result.status
-        error.response = result
+        error.ErrorMessage = body.ErrorMessage || err.message
+        error.statusCode = err.status || null
+        error.response = result || null
         return ret(error)
       }
 

--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -103,10 +103,9 @@ MailjetClient.connect = function (k, s, o) {
  *
  */
 MailjetClient.prototype.connect = function (apiKey, apiSecret, options) {
-  var options = options || {}
   this.apiKey = apiKey
   this.apiSecret = apiSecret
-  this.proxyUrl = options.proxyUrl
+  this.options = options || {}
   return this
 }
 
@@ -159,8 +158,8 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback) {
 
     .auth(this.apiKey, this.apiSecret)
 
-  if (this.proxyUrl) {
-    req = req.proxy(this.proxyUrl)
+  if (this.options.proxyUrl) {
+    req = req.proxy(this.options.proxyUrl)
   }
 
   const payload = method === 'post' || method === 'put' ? data : {}

--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -54,18 +54,18 @@ require('superagent-proxy')(request);
  *
  * @qpi_key (optional) {String} mailjet account api key
  * @api_secret (optional) {String} mailjet account api secret
- * @proxy_url (optional) {String} proxy URL for HTTPS requests
+ * @options (optional) {Object} additional connection options
  *
  * If you don't know what this is about, sign up to Mailjet at:
  * https://www.mailjet.com/
  */
-function MailjetClient (api_key, api_secret, proxy_url, testMode) {
+function MailjetClient (api_key, api_secret, options, testMode) {
   this.config = require('./config')
   this.testMode = testMode || false
   // To be updated according to the npm repo version
   this.version = version
   if (api_key && api_secret) {
-    this.connect(api_key, api_secret, proxy_url)
+    this.connect(api_key, api_secret, options)
   }
 }
 
@@ -85,11 +85,11 @@ MailjetClient.prototype.typeJson = function (body) {
  *
  * @k {String} mailjet qpi key
  * @s {String} mailjet api secret
- * @p {String} optional proxy URL
+ * @o {String} optional connection options
  *
  */
-MailjetClient.connect = function (k, s, p) {
-  return new MailjetClient().connect(k, s, p)
+MailjetClient.connect = function (k, s, o) {
+  return new MailjetClient().connect(k, s, o)
 }
 
 /*
@@ -99,13 +99,14 @@ MailjetClient.connect = function (k, s, p) {
  *
  * @apiKey {String}
  * @apiSecret {String}
- * @proxyUrl {String}
+ * @options {Object}
  *
  */
-MailjetClient.prototype.connect = function (apiKey, apiSecret, proxyUrl) {
+MailjetClient.prototype.connect = function (apiKey, apiSecret, options) {
+  var options = options || {}
   this.apiKey = apiKey
   this.apiSecret = apiSecret
-  this.proxyUrl = proxyUrl
+  this.proxyUrl = options.proxyUrl
   return this
 }
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "superagent-proxy": "^1.0.1"
   },
   "devDependencies": {
-    "mocha": "^2.4.5",
     "chai": "^3.2.0",
+    "mocha": "^2.4.5",
+    "nock": "^8.1.0",
     "to-iso-string": "0.0.2"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "bluebird": "^3.3.5",
     "json-bigint": "^0.2.0",
     "qs": "^4.0.0",
-    "superagent": "^2.0.0"
+    "superagent": "^2.0.0",
+    "superagent-proxy": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "^2.4.5",

--- a/test/test.js
+++ b/test/test.js
@@ -36,18 +36,17 @@ describe('Basic Usage', function () {
     })
 
     it('creates an instance of the client with options', function () {
-      var proxyUrl = 'http://localhost:3128'
-      var expectedMembers = { apiKey: API_KEY, apiSecret: API_SECRET, proxyUrl: proxyUrl }
+      var options = { proxyUrl: 'http://localhost:3128' }
 
-      var connectionType1 = new Mailjet(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
-      var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
-      var connectionType3 = Mailjet.connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+      var connectionType1 = new Mailjet(API_KEY, API_SECRET, options)
+      var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, options)
+      var connectionType3 = Mailjet.connect(API_KEY, API_SECRET, options)
 
       var connections = [connectionType1, connectionType2, connectionType3]
       connections.forEach(function (connection) {
         expect(connection).to.have.property('apiKey', API_KEY)
         expect(connection).to.have.property('apiSecret', API_SECRET)
-        expect(connection.options).to.have.property('proxyUrl', proxyUrl)
+        expect(connection.options).to.have.property('proxyUrl', options.proxyUrl)
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,22 @@ describe('Basic Usage', function () {
       expect('' + connectionType2.apiKey + connectionType2.apiSecret).to.equal('' + API_KEY + API_SECRET)
       expect('' + connectionType3.apiKey + connectionType3.apiSecret).to.equal('' + API_KEY + API_SECRET)
     })
+
+    it('creates an instance of the client with options', function () {
+      var proxyUrl = 'http://localhost:3128'
+      var expectedMembers = { apiKey: API_KEY, apiSecret: API_SECRET, proxyUrl: proxyUrl }
+
+      var connectionType1 = new Mailjet(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+      var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+      var connectionType3 = Mailjet.connect(API_KEY, API_SECRET, { proxyUrl: proxyUrl })
+
+      var connections = [connectionType1, connectionType2, connectionType3]
+      connections.forEach(function (connection) {
+        expect(connection).to.have.property('apiKey', API_KEY)
+        expect(connection).to.have.property('apiSecret', API_SECRET)
+        expect(connection).to.have.property('proxyUrl', proxyUrl)
+      })
+    })
   })
 
   describe('method request', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -47,7 +47,7 @@ describe('Basic Usage', function () {
       connections.forEach(function (connection) {
         expect(connection).to.have.property('apiKey', API_KEY)
         expect(connection).to.have.property('apiSecret', API_SECRET)
-        expect(connection).to.have.property('proxyUrl', proxyUrl)
+        expect(connection.options).to.have.property('proxyUrl', proxyUrl)
       })
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -130,7 +130,7 @@ describe('Advanced API Calls', function () {
     }
   }
 
-  var client2 = new Mailjet(API_KEY, API_SECRET, true)
+  var client2 = new Mailjet(API_KEY, API_SECRET, null, true)
 
   const EXAMPLES_SET = [
     new Example(client2.get('contact')),

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,8 @@ var chai = require('chai')
 var expect = chai.expect
 var should = chai.should() // eslint-disable-line no-unused-vars
 var Promise = require('bluebird')
+var nock = require('nock')
+
 if (typeof API_KEY === 'undefined' || typeof API_SECRET === 'undefined') {
   throw new Error('Mailjet API_KEY and API_SECRET are required, respectively ' + API_KEY + ' and ' + API_SECRET + ' given ')
 }
@@ -36,7 +38,10 @@ describe('Basic Usage', function () {
     })
 
     it('creates an instance of the client with options', function () {
-      var options = { proxyUrl: 'http://localhost:3128' }
+      var options = {
+        proxyUrl: 'http://localhost:3128',
+        timeout: 10000
+      }
 
       var connectionType1 = new Mailjet(API_KEY, API_SECRET, options)
       var connectionType2 = new Mailjet().connect(API_KEY, API_SECRET, options)
@@ -47,6 +52,7 @@ describe('Basic Usage', function () {
         expect(connection).to.have.property('apiKey', API_KEY)
         expect(connection).to.have.property('apiSecret', API_SECRET)
         expect(connection.options).to.have.property('proxyUrl', options.proxyUrl)
+        expect(connection.options).to.have.property('timeout', 10000)
       })
     })
   })
@@ -190,6 +196,39 @@ describe('Advanced API Calls', function () {
   EXPECTED_SET.forEach(function (test, index) {
     it('should output: ' + test, function () {
       EXAMPLES_SET[index].call().should.equal(test)
+    })
+  })
+})
+
+/* This fixture needs to run last so that it doesn't interfere with the other tests */
+describe('Mocked API calls', function () {
+  /* Set a very short timeout */
+  var client = Mailjet.connect(API_KEY, API_SECRET, { timeout: 10 })
+
+  describe('method request', function () {
+    describe('get', function () {
+      var contact = client.get('contact')
+
+      it('calls the contact resource instance and the request times out', function (done) {
+        /* Simulate a delayed response */
+        nock('https://api.mailjet.com')
+          .get('/v3/REST/contact')
+          .delayConnection(1000)
+          .reply(200, {})
+
+        contact.request({})
+          .then(function (result) {
+            // We want it to raise an error if it gets here
+            expect(result).to.equal(undefined)
+            done()
+          })
+          .catch(function (reason) {
+            expect(reason.ErrorMessage).to.equal('timeout of 10ms exceeded')
+            expect(reason.statusCode).to.equal(null)
+            expect(reason.response).to.equal(null)
+            done()
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
As @lukastl21 pointed out in #17, request timeouts or other errors caused by not reaching the API server are returned as successes. Fix that by examining the `err` argument returned by `superagent` to detect failures.

This pull request is based on top of #18 because it requires a timeout option to be passed to the client in order to trigger a timeout in tests, and #18 adds an `options` argument that can be used for that. So #18 would preferably be merged before this one.
