### PR TITLE
fix perform_api_call and return promise always

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -61,7 +61,7 @@ require('superagent-proxy')(request);
  */
 function MailjetClient (api_key, api_secret, options, perform_api_call) {
   this.config = this.setConfig(options);
-  this.perform_api_call = perform_api_call || false
+  this.perform_api_call = perform_api_call || true
   // To be updated according to the npm repo version
   this.version = version
   if (api_key && api_secret) {
@@ -192,8 +192,8 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback, per
     console.log('body: ' + payload)
   }
   
-  if (perform_api_call === false || this.perform_api_call) {
-    return [url, payload]
+  if (perform_api_call === false || this.perform_api_call === false) {
+    return Promise.resolve({body: {}})
   }
   
   if (method === 'delete') { method = 'del' }


### PR DESCRIPTION
This PR fixes two issues:
#### 1
There are two types of `perform_api_call` flags, one is defined as property of a the MailjetClient context instance:
```
function MailjetClient (api_key, api_secret, options, perform_api_call) {
  this.perform_api_call = perform_api_call || true
  /* ... */
}
```
And the other is specified as an argument in the signature of httpRequest:
```
MailjetClient.prototype.httpRequest = function (method, url, data, callback, perform_api_call){
  if (perform_api_call === false || this.perform_api_call) { /* do not perform an api call */ }  
```

The first one defaults to false, while the second is only checked against `false` and  `or`ed with the first one. So they have opposite logic which is totally confusing.

---

#### 2

When turning perform_api_call off (do not perform an API call) the response become not a promise anymore, which means the end user needs to distinguish which doesn't allow a proper testing. Currently it returns just a value (not as a promise) this `[url, payload]` which is also very confusing, why it returns an array of url and payload of the the request? I want to have something which looks similar to the response of the request. 
Since I'm not sure for which use cases `httpRequest` is used I didn't return a dummy of a `mailer.post('send')` response, instead just an empty payload (of course wrapped in a body property) 