### PR TITLE
fix: always a promise

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -191,7 +191,7 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback, per
   }
   
   if (perform_api_call === false || this.perform_api_call) {
-    return [url, payload]
+    return Promise.resolve([url, payload])
   }
   
   if (method === 'delete') { method = 'del' }


### PR DESCRIPTION
always a promise even when testing


when `perform_api_call: false` the existing code is relying on the return value being a promise