### PR TITLE
Ensures that test mode uses the provided callback or promise

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -190,13 +190,6 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback, per
     console.log('body: ' + payload)
   }
   
-  if (perform_api_call === false || this.perform_api_call) {
-    return [url, payload]
-  }
-  
-  if (method === 'delete') { method = 'del' }
-  if (method === 'post' || method === 'put') { req = req.send(data) }
-
   return new Promise(function (resolve, reject) {
 
     const ret = function (err, result) {
@@ -206,7 +199,13 @@ MailjetClient.prototype.httpRequest = function (method, url, data, callback, per
         ? reject(err)
         : resolve(result)
     }
-
+    if (perform_api_call === false || this.perform_api_call) {
+      return ret(null, { response: { statusCode: 200 }, url, body: payload })
+    }
+  
+    if (method === 'delete') { method = 'del' }
+    if (method === 'post' || method === 'put') { req = req.send(data) }
+    
     req.end(function (err, result) {
       var body
 


### PR DESCRIPTION
When `perform_api_call === false` MailJet request function returns a value instead of resolving the promise or the callback.

This PR attempts to handle both callback and promise whereas https://github.com/mailjet/mailjet-apiv3-nodejs/pull/44 only resolves a promise.

Credit to @gdi2290 for identifying the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailjet/mailjet-apiv3-nodejs/52)
<!-- Reviewable:end -->
