### PR TITLE
added details of error mesage into error.message

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -484,8 +484,21 @@ MailjetResource.prototype.action = function (name) {
  */
 
 MailjetResource.prototype.request = function (params, callback) {
-  return this.result(params, callback)
-}
+  return this.result(params, callback).catch(function (err) {
+    try {
+      const ErrorDetails = JSON.parse(err.response.text);
+      const fullMessage = ErrorDetails.Messages[0].Errors[0].ErrorMessage;
+
+      if (typeof fullMessage === "string") {
+        err.message = err.message + ";\n" + fullMessage;
+        throw err;
+      }
+      throw err;
+    } catch {
+      throw err;
+    }
+  });
+};
 
 /*
  * post.


### PR DESCRIPTION
fixed issue related to https://github.com/mailjet/mailjet-apiv3-nodejs/issues/101

example of error message
```
Unsuccessful: 400 Bad Request;
At least "HTMLPart", "TextPart" or "TemplateID" must be provided.
```