### PR TITLE
Update superagent and superagent-proxy dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "superagent-proxy": "^2.1.0"
   },
   "devDependencies": {
-    "@segment/to-iso-string": "^1.0.1",
     "chai": "^4.1.0",
-    "eslint": "^4.2.0",
     "mocha": "^5.2.0",
-    "nock": "^9.0.14"
+    "nock": "^9.0.14",
+    "@segment/to-iso-string": "^1.0.1",
+    "eslint": "^4.2.0"
   },
   "scripts": {
     "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -10,15 +10,15 @@
     "bluebird": "^3.5.0",
     "json-bigint": "^0.2.3",
     "qs": "^6.5.0",
-    "superagent": "^3.5.2",
-    "superagent-proxy": "^1.0.2"
+    "superagent": "^6.1.0",
+    "superagent-proxy": "^2.1.0"
   },
   "devDependencies": {
-    "chai": "^4.1.0",
-    "mocha": "^5.2.0",
-    "nock": "^9.0.14",
     "@segment/to-iso-string": "^1.0.1",
-    "eslint": "^4.2.0"
+    "chai": "^4.1.0",
+    "eslint": "^4.2.0",
+    "mocha": "^5.2.0",
+    "nock": "^9.0.14"
   },
   "scripts": {
     "test": "mocha"


### PR DESCRIPTION
Addressing https://github.com/mailjet/mailjet-apiv3-nodejs/issues/128
Tests are green in my local environment. We are already using this version in our application without any apparent problems.