### PR TITLE
Fixed CommonJS antipattern which could cause random errors

### DIFF
--- a/config-mailjet-default.js
+++ b/config-mailjet-default.js
@@ -1,4 +1,4 @@
-{
+export default {
   "url": "api.mailjet.com",
   "version": "v3",
   "output": "json",

--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -208,7 +208,7 @@ MailjetClient.prototype.connectStrategy = function (apiKey, apiSecret, options) 
 }
 
 MailjetClient.prototype.setConfig = function (options) {
-  const config = require('./config')
+  const config = require('./config-mailjet-default')
   if (typeof options === 'object' && options != null && options.length != 0) {
     if (options.url) config.url = options.url
     if (options.version) config.version = options.version


### PR DESCRIPTION
Hello,

We are having troubles using your library in an Angular-Universal app.
After troubleshooting, we found the error : in the MailjetClient, you are importing a JSON file (./config.json) using CommonJS.

This is not the default nor recommended behaviour, as CommonJS specifies it should be used only for either JS or TS extensions (.js, .ts) and can cause import errors such as "Can't resolve ./config" in ".../node-mailjet" in different projects using the default or recommended configuration . Example of an old issue which had the same error, though the provided fix was not the right one: 
#121  https://github.com/mailjet/mailjet-apiv3-nodejs/issues/121

In this commit, I propose to move your local config.json file to a config-mailjet-default.js file, allowing a good use of CommonJS standards 