### PR TITLE
fix wrong route error

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -258,7 +258,7 @@ MailjetClient.prototype.path = function (resource, sub, params, options) {
   }
 
   var q = qs.stringify(params);
-  return _path.join(url, base + '/' + resource + '/?' + q)
+  return _path.join(url, base + '/' + resource + '?' + q)
 }
 
 /*


### PR DESCRIPTION
when you try to do :
mailjet.get("template").request({ Limit: 1000 })
it calls the wrong route 
/template/id instead of /template
this fixes it