### PR TITLE
Include ErrorRelatedTo in MailjetResource.prototype.request throws

### DIFF
--- a/mailjet-client.js
+++ b/mailjet-client.js
@@ -492,9 +492,13 @@ MailjetResource.prototype.request = function (params, callback) {
     try {
       const ErrorDetails = JSON.parse(err.response.text);
       const fullMessage = ErrorDetails.Messages[0].Errors[0].ErrorMessage;
+      const relatedTo = ErrorDetails.Messages[0].Errors[0].ErrorRelatedTo;
 
       if (typeof fullMessage === "string") {
         err.message = err.message + ";\n" + fullMessage;
+        if (Array.isArray(relatedTo) && relatedTo.length > 0) {
+          err.message += ";\nRelated To:" + relatedTo.join(", ");
+        }
         throw err;
       }
       throw err;


### PR DESCRIPTION
Some errors are triggered by differents elements, like mj-0008 which can rely on 
Messages
Attachments
InlineAttachments
Headers
Variables

But this information is not sended by the library, making it hard to investigate when we have production incident with fails on a specific error.