### PR TITLE
update superagent-proxy package to 3.0.0 to fix high vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "json-bigint": "^1.0.0",
     "qs": "^6.5.0",
     "superagent": "^6.1.0",
-    "superagent-proxy": "^2.1.0"
+    "superagent-proxy": "^3.0.0"
   },
   "devDependencies": {
     "@segment/to-iso-string": "^1.0.1",


### PR DESCRIPTION
This update is needed to fix the pac-resolver vulnerability : https://www.npmjs.com/advisories/1784