### PR TITLE
Update version field typing

### DIFF
--- a/dist/declarations/client/index.d.ts
+++ b/dist/declarations/client/index.d.ts
@@ -16,7 +16,7 @@ declare class Client {
     getAPIToken(): string | undefined;
     getConfig(): {
         host: string;
-        version: string;
+        version: `v${number}` | `v${number}.${number}`;
         output: import("axios").ResponseType;
     };
     getOptions(): {

--- a/dist/declarations/request/Request.d.ts
+++ b/dist/declarations/request/Request.d.ts
@@ -2,7 +2,7 @@ import { AxiosProxyConfig, AxiosRequestConfig, AxiosRequestHeaders, ResponseType
 import { TObject } from '../types';
 export interface RequestConfig {
     host: string;
-    version: string;
+    version: `v${number}` | `v${number}.${number}`;
     output: ResponseType;
 }
 export interface RequestOptions {

--- a/lib/request/Request.ts
+++ b/lib/request/Request.ts
@@ -13,7 +13,7 @@ import { TObject } from '../types';
 
 export interface RequestConfig {
   host: string;
-  version: string;
+  version: `v${number}` | `v${number}.${number}`;
   output: ResponseType;
 }
 

--- a/test/integration/sms.test.ts
+++ b/test/integration/sms.test.ts
@@ -5,6 +5,7 @@ import { expect } from 'chai';
 import { isUndefined } from '../../lib/utils';
 /*lib*/
 import Mailjet, { Request } from '../../lib/index';
+import { RequestConfig } from '../../lib/request/Request';
 /*other*/
 
 describe('SMS Basic Usage', () => {
@@ -15,7 +16,7 @@ describe('SMS Basic Usage', () => {
     if (isUndefined(API_TOKEN)) {
       this.skip();
     } else {
-      const smsConfig = {
+      const smsConfig: Partial<RequestConfig> = {
         version: 'v4',
       };
       client = Mailjet.smsConnect(API_TOKEN, { config: smsConfig });
@@ -33,7 +34,7 @@ describe('SMS Basic Usage', () => {
     });
 
     it('creates an instance of the client wiht options', () => {
-      const smsConfig = {
+      const smsConfig: Partial<RequestConfig> = {
         version: 'v4',
       };
 


### PR DESCRIPTION
This PR updates the type of the `version` field (in `RequestConfig`) to only allow strings like `vX` (where `X` is a number), or `vX.Y`. Feel free to comment and/or edit.