### PR TITLE
chore: Bump axios to latest version

### DIFF
--- a/lib/request/Request.ts
+++ b/lib/request/Request.ts
@@ -2,7 +2,7 @@
 import {
   AxiosProxyConfig,
   AxiosRequestConfig,
-  AxiosRequestHeaders,
+  RawAxiosRequestHeaders,
   ResponseType,
 } from 'axios';
 /*types*/
@@ -20,7 +20,7 @@ export interface RequestConfig {
 export interface RequestOptions {
   timeout?: number;
   proxy?: AxiosProxyConfig;
-  headers?: AxiosRequestHeaders;
+  headers?: RawAxiosRequestHeaders;
   maxBodyLength?: number;
   maxContentLength?: number;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.4",
       "license": "MIT",
       "dependencies": {
-        "axios": "^0.27.2",
+        "axios": "^1.6.1",
         "json-bigint": "^1.0.0",
         "url-join": "^4.0.0"
       },
@@ -3394,12 +3394,13 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -8144,6 +8145,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -12958,12 +12964,13 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-loader": {
@@ -16504,6 +16511,11 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -64,12 +64,11 @@
     "docs": "typedoc --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "axios": "^0.27.2",
-    "url-join": "^4.0.0",
-    "json-bigint": "^1.0.0"
+    "axios": "^1.6.1",
+    "json-bigint": "^1.0.0",
+    "url-join": "^4.0.0"
   },
   "devDependencies": {
-    "qs": "^6.5.0",
     "@babel/core": "^7.18.0",
     "@babel/preset-env": "^7.18.0",
     "@commitlint/cli": "^17.0.2",
@@ -94,6 +93,7 @@
     "mocha": "^9.0.0",
     "nock": "^13.2.4",
     "nyc": "^15.1.0",
+    "qs": "^6.5.0",
     "standard-version": "^9.5.0",
     "terser-webpack-plugin": "^5.3.1",
     "ts-loader": "^9.3.0",


### PR DESCRIPTION
Fixes [CVE-2023-45857](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx)