### PR TITLE
fix: Add default timeout and opt-in retry support to prevent ETIMEDOU…

### DIFF
--- a/lib/request/Request.ts
+++ b/lib/request/Request.ts
@@ -23,6 +23,8 @@ export interface RequestOptions {
   headers?: RawAxiosRequestHeaders;
   maxBodyLength?: number;
   maxContentLength?: number;
+  maxRetries?: number;
+  retryDelay?: number;
 }
 
 export type SubPath = 'REST' | 'DATA' | '';

--- a/lib/request/index.ts
+++ b/lib/request/index.ts
@@ -163,9 +163,9 @@ class Request {
     const clientOptions = this.client.getOptions();
 
     // 1. Timeout
-    if (clientOptions.timeout) {
-      requestConfig.timeout = clientOptions.timeout;
-    }
+    requestConfig.timeout = clientOptions.timeout !== undefined
+      ? clientOptions.timeout
+      : Request.DEFAULT_TIMEOUT;
 
     // 2. Proxy
     if (clientOptions.proxy) {
@@ -277,68 +277,104 @@ class Request {
       } as LibraryLocalResponse<Body, Params>;
     }
 
-    try {
-      const response = await this.makeRequest(url, data, params);
-      return {
-        response,
-        body: response.data,
-      };
-    } catch (err: unknown) {
-      if (err instanceof AxiosError) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const error = new Error() as any;
+    const clientOptions = this.client.getOptions();
+    const maxRetries = clientOptions.maxRetries ?? 0;
+    const retryDelay = clientOptions.retryDelay ?? 1000;
 
-        error.code = err.code;
-        error.config = err.config;
-
-        if (err.response) {
-          const {
-            status,
-            statusText,
-            data: body,
-          } = err.response;
-
-          error.response = err.response;
-
-          error.statusCode = status;
-          error.statusText = statusText;
-
-          const errorMessage = body?.ErrorMessage ?? err.message;
-          error.originalMessage = errorMessage;
-          error.message = `Unsuccessful: Status Code: "${error.statusCode}" Message: "${errorMessage}"`;
-
-          if (body) {
-            // https://dev.mailjet.com/email/guides/send-api-v31/#send-in-bulk
-            const fullMessage = body.Messages?.[0]?.Errors?.[0]?.ErrorMessage;
-            if (typeof fullMessage === 'string') {
-              error.message += `;\n${fullMessage}`;
-            }
-
-            // v3.1 case
-            // https://dev.mailjet.com/email/guides/send-api-v31/#sandbox-mode
-            setValueIfNotNil(error, 'ErrorMessage', body.ErrorMessage);
-            setValueIfNotNil(error, 'ErrorCode', body.ErrorCode);
-            setValueIfNotNil(error, 'ErrorIdentifier', body.ErrorIdentifier);
-            setValueIfNotNil(error, 'ErrorRelatedTo', body.ErrorRelatedTo);
-          }
-        } else {
-          error.response = null;
-
-          error.statusCode = null;
-          error.statusText = null;
-
-          error.originalMessage = err.message;
-          error.message = `Unsuccessful: Error Code: "${error.code}" Message: "${err.message}"`;
-        }
-
-        throw error;
+    // eslint-disable-next-line no-plusplus
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (attempt > 0) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, retryDelay * (2 ** (attempt - 1)));
+        });
       }
 
-      throw err;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const response = await this.makeRequest(url, data, params);
+        return {
+          response,
+          body: response.data,
+        };
+      } catch (err: unknown) {
+        if (err instanceof AxiosError) {
+          const isNetworkError = !err.response;
+          const isRetryable = isNetworkError && Request.RETRYABLE_ERROR_CODES.has(err.code ?? '');
+
+          if (isRetryable && attempt < maxRetries) {
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const error = new Error() as any;
+
+          error.code = err.code;
+          error.config = err.config;
+
+          if (err.response) {
+            const {
+              status,
+              statusText,
+              data: body,
+            } = err.response;
+
+            error.response = err.response;
+
+            error.statusCode = status;
+            error.statusText = statusText;
+
+            const errorMessage = body?.ErrorMessage ?? err.message;
+            error.originalMessage = errorMessage;
+            error.message = `Unsuccessful: Status Code: "${error.statusCode}" Message: "${errorMessage}"`;
+
+            if (body) {
+              // https://dev.mailjet.com/email/guides/send-api-v31/#send-in-bulk
+              const fullMessage = body.Messages?.[0]?.Errors?.[0]?.ErrorMessage;
+              if (typeof fullMessage === 'string') {
+                error.message += `;\n${fullMessage}`;
+              }
+
+              // v3.1 case
+              // https://dev.mailjet.com/email/guides/send-api-v31/#sandbox-mode
+              setValueIfNotNil(error, 'ErrorMessage', body.ErrorMessage);
+              setValueIfNotNil(error, 'ErrorCode', body.ErrorCode);
+              setValueIfNotNil(error, 'ErrorIdentifier', body.ErrorIdentifier);
+              setValueIfNotNil(error, 'ErrorRelatedTo', body.ErrorRelatedTo);
+            }
+          } else {
+            error.response = null;
+
+            error.statusCode = null;
+            error.statusText = null;
+
+            error.originalMessage = err.message;
+            error.message = `Unsuccessful: Error Code: "${error.code}" Message: "${err.message}"`;
+          }
+
+          throw error;
+        }
+
+        throw err;
+      }
     }
+
+    // unreachable — loop always returns or throws
+    throw new Error('Unexpected end of retry loop');
   }
 
   public static protocol = 'https://' as const;
+
+  private static readonly DEFAULT_TIMEOUT = 30_000;
+
+  private static readonly RETRYABLE_ERROR_CODES = new Set([
+    'ETIMEDOUT',
+    'ECONNABORTED',
+    'ECONNRESET',
+    'ECONNREFUSED',
+    'ENOTFOUND',
+  ]);
 
   public static parseToJSONb(text: string) {
     if (typeof text !== 'string') {

--- a/test/integration/mocked.test.ts
+++ b/test/integration/mocked.test.ts
@@ -64,6 +64,34 @@ describe('Mocked API calls', () => {
           nock.cleanAll();
         }
       });
+
+      it('succeeds on retry after a transient ETIMEDOUT error', async () => {
+        const resultData = { Count: 1, Data: [] };
+
+        /* First attempt: simulate ETIMEDOUT (the error from the ticket) */
+        nock('https://api.mailjet.com')
+          .get('/v3/REST/contact')
+          .replyWithError({ code: 'ETIMEDOUT', message: 'connect ETIMEDOUT 35.187.79.8:443' });
+
+        /* Second attempt (retry): succeeds */
+        nock('https://api.mailjet.com')
+          .defaultReplyHeaders({ 'Content-Type': 'application/json' })
+          .get('/v3/REST/contact')
+          .reply(200, resultData);
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const retryClient = Mailjet.apiConnect(API_KEY!, API_SECRET!, {
+          config: { version: 'v3' },
+          options: { timeout: REQUEST_TIMEOUT, maxRetries: 1, retryDelay: 0 },
+        });
+
+        const result = await retryClient.get('contact').request();
+
+        expect(result).to.be.a('object');
+        expect(result).to.have.ownProperty('body').that.deep.equals(resultData);
+
+        nock.cleanAll();
+      });
     });
   });
 });

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -847,6 +847,27 @@ describe('Unit Request', () => {
         expect(requestData.headers).to.haveOwnProperty('accept').that.includes('application/json');
       });
 
+      it('should apply default timeout of 30000ms when no timeout is configured', async () => {
+        const resource = 'contact';
+        const path = `/${Client.config.version}/REST/${resource}`;
+
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+        };
+
+        const resultData = { Count: 1 };
+        nock(API_MAILJET_URL)
+          .defaultReplyHeaders({ 'Content-Type': 'application/json' })
+          .get(path)
+          .reply(200, JSON.stringify(resultData));
+
+        const instance = new Client(params).get(resource);
+        const result = await instance.request();
+
+        expect(result.response.config).to.have.ownProperty('timeout').that.equals(30000);
+      });
+
       it('should be request with proxy', async () => {
         const resource = 'contact';
         const path = `/${Client.config.version}/REST/${resource}`;
@@ -1447,6 +1468,124 @@ describe('Unit Request', () => {
 
           expect(err.config.timeout).to.equal(params.options?.timeout);
         } finally {
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(error).to.be.not.null;
+        }
+      });
+
+      it('should succeed on retry after a transient ETIMEDOUT network error', async () => {
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+          options: {
+            maxRetries: 1,
+            retryDelay: 0,
+          },
+        };
+
+        const resultData = { Count: 1, Data: [] };
+
+        let callCount = 0;
+        const originalMakeRequest = Request.prototype['makeRequest'];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Request.prototype['makeRequest'] = async function (): Promise<any> {
+          callCount += 1;
+          if (callCount === 1) {
+            throw new AxiosError('connect ETIMEDOUT 35.187.79.8:443', 'ETIMEDOUT');
+          }
+          return {
+            data: resultData,
+            status: 200,
+            statusText: 'OK',
+            headers: {},
+            config: {},
+            request: {},
+          };
+        };
+
+        try {
+          const instance = new Client(params).get('contact');
+          const result = await instance.request();
+
+          expect(callCount).to.equal(2);
+          expect(result).to.be.a('object');
+          expect(result).to.have.ownProperty('body').that.deep.equals(resultData);
+        } finally {
+          Request.prototype['makeRequest'] = originalMakeRequest;
+        }
+      });
+
+      it('should throw after exhausting all retries on persistent network errors', async () => {
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+          options: {
+            maxRetries: 1,
+            retryDelay: 0,
+          },
+        };
+
+        let callCount = 0;
+        const originalMakeRequest = Request.prototype['makeRequest'];
+        Request.prototype['makeRequest'] = async function () {
+          callCount += 1;
+          throw new AxiosError('connect ETIMEDOUT 35.187.79.8:443', 'ETIMEDOUT');
+        };
+
+        let error = null;
+        try {
+          const instance = new Client(params).get('contact');
+          await instance.request();
+        } catch (err) {
+          error = err;
+
+          expectOwnProperty(err, 'code', 'ETIMEDOUT');
+          expectOwnProperty(err, 'response', null);
+          expectOwnProperty(err, 'statusCode', null);
+          expect(callCount).to.equal(2);
+        } finally {
+          Request.prototype['makeRequest'] = originalMakeRequest;
+          // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+          expect(error).to.be.not.null;
+        }
+      });
+
+      it('should not retry on HTTP error responses', async () => {
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+          options: {
+            maxRetries: 2,
+            retryDelay: 0,
+          },
+        };
+
+        let callCount = 0;
+        const originalMakeRequest = Request.prototype['makeRequest'];
+        Request.prototype['makeRequest'] = async function () {
+          callCount += 1;
+          const axiosError = new AxiosError('Request failed with status code 500', 'ERR_BAD_RESPONSE');
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (axiosError as any).response = {
+            status: 500,
+            statusText: 'Internal Server Error',
+            data: { ErrorMessage: 'Internal Server Error' },
+          };
+          throw axiosError;
+        };
+
+        let error = null;
+        try {
+          const instance = new Client(params).get('contact');
+          await instance.request();
+        } catch (err) {
+          error = err;
+
+          expectOwnProperty(err, 'statusCode', 500);
+          expect(err).to.haveOwnProperty('response').that.is.an('object');
+          expect(callCount).to.equal(1);
+        } finally {
+          Request.prototype['makeRequest'] = originalMakeRequest;
           // eslint-disable-next-line @typescript-eslint/no-unused-expressions
           expect(error).to.be.not.null;
         }


### PR DESCRIPTION
…T hangs

Requests to the Mailjet API could hang indefinitely when the remote IP was unreachable because no default timeout was set on the axios client. Additionally, transient network errors such as ETIMEDOUT had no recovery path, causing immediate failure with no retry.

- Set a 30 s default timeout so unconfigured clients fail fast instead of waiting on the OS TCP stack (which can take minutes)
- Add `maxRetries` and `retryDelay` options to `RequestOptions` for opt-in exponential-backoff retries on transient network errors (ETIMEDOUT, ECONNABORTED, ECONNRESET, ECONNREFUSED, ENOTFOUND); HTTP error responses (4xx/5xx) are never retried
- Default `maxRetries` is 0, preserving existing behaviour for all current users

Closes #266