### PR TITLE
fix: Guard against calling id() after action() to prevent wrong templ…

### DIFF
--- a/lib/request/index.ts
+++ b/lib/request/index.ts
@@ -211,6 +211,10 @@ class Request {
       throw new Error('Argument "value" must be string or number');
     }
 
+    if (this.actionPath !== null) {
+      throw new Error('id() must be called before action()');
+    }
+
     this.url = urlJoin(this.url, value.toString());
 
     return this;

--- a/test/integration/base.test.ts
+++ b/test/integration/base.test.ts
@@ -226,6 +226,7 @@ describe('API Basic Usage', () => {
       'https://api.mailjet.com/v3/DATA/contactslist/34/csvdata/text:plain "FILE"',
       'https://api.mailjet.com/v3/REST/newsletter?CountOnly=1 {}',
       'https://api.mailjet.com/v3/DATA/batchjob/csverror/text:csv {}',
+      'https://api.mailjet.com/v3/REST/template/456/detailcontent {}',
       'https://api.mailjet.com/v3/REST/contact {"email":"test@mailjet.com"}',
       'https://api.mailjet.com/v3/send {"FromName":"name","FromEmail":"test@mailjet.com","Subject":"subject","Text-Part":"text","Recipients":[{"email":"test@mailjet.com"}]}',
       'https://api.mailjet.com/v3/send {"FromName":"name","FromEmail":"test@mailjet.com","Subject":"subject","Text-Part":"text","Recipients":[{"email":"test@mailjet.com"},{"email":"test2@mailjet.com"}]}',
@@ -254,6 +255,7 @@ describe('API Basic Usage', () => {
           new Example(apiClient.post('contactslist').id(34).action('csvdata'), { data: FILE }),
           new Example(apiClient.get('newsletter'), { params: { CountOnly: 1 } }),
           new Example(apiClient.get('batchjob').action('csverror')),
+          new Example(apiClient.put('template').id(456).action('detailcontent')),
           new Example(apiClient.post('contact'), { data: { email: EMAIL } }),
           new Example(apiClient.post('send'), {
             data: {

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -434,6 +434,18 @@ describe('Unit Request', () => {
         expect(path).to.be.a('string');
         expect(path).to.equal(url);
       });
+
+      it('should build correct URL for template detailcontent when id() precedes action()', () => {
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+        };
+
+        const request = new Client(params).put('template').id(123).action('detailcontent');
+        const url = request['buildFullUrl']();
+
+        expect(url).to.equal(`${Request.protocol}${Client.config.host}/v3/REST/template/123/detailcontent`);
+      });
     });
 
     describe('Request.buildSubPath()', () => {
@@ -581,6 +593,17 @@ describe('Unit Request', () => {
           expect(() => Request.prototype.id.call(null, value as string))
             .to.throw(Error, 'Argument "value" must be string or number');
         });
+      });
+
+      it('should throw error if id() is called after action()', () => {
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+        };
+
+        expect(
+          () => new Client(params).put('template').action('detailcontent').id(123),
+        ).to.throw(Error, 'id() must be called before action()');
       });
     });
 


### PR DESCRIPTION
…ate URLs

When action() was called before id() on a Request chain, the resulting URL had path segments reversed — e.g. /REST/template/detailcontent/123 instead of /REST/template/123/detailcontent. Mailjet's API interpreted this malformed URL in an undefined way, causing it to create a new draft version from a different template rather than updating the intended one.

Add a guard in id() that throws immediately if action() was already called, making the wrong order a loud failure instead of a silent data-corruption bug. All existing call chains (id before action) are unaffected.

Also adds a unit test for the guard, a URL correctness test for the template/detailcontent pattern, and a regression entry in the integration URL output set.

Closes #276