### PR TITLE
fix: Validate contactdata PUT payload shape to prevent Invalid key na…

### DIFF
--- a/README.md
+++ b/README.md
@@ -859,6 +859,11 @@ It also means that all non-mandatory properties can be omitted from your payload
 
 Update the **contact properties** for a **contact**:
 
+Each entry in `Data` must be an object with `Name` and `Value` keys, where `Name` matches
+a property already defined via [`/contactmetadata`](https://dev.mailjet.com/email/reference/contacts/contact-properties/#v3_post_contactmetadata).
+Sending the property name/value directly (e.g. `{ first_name: "John" }`) instead of
+`{ Name: "first_name", Value: "John" }` will make the API respond with an `Invalid key name` error.
+
 ```javascript
 const Mailjet = require('node-mailjet')
 const mailjet = new Mailjet({
@@ -872,8 +877,12 @@ const request = mailjet
         .request({
           Data: [
             {
-              first_name: "John",
-              last_name: "Smith"
+              Name: "first_name",
+              Value: "John"
+            },
+            {
+              Name: "last_name",
+              Value: "Smith"
             }
           ]
         })

--- a/lib/request/index.ts
+++ b/lib/request/index.ts
@@ -4,7 +4,7 @@ import JSONBigInt from 'json-bigint';
 import axios, { AxiosError } from 'axios';
 /*utils*/
 import {
-  isNonEmptyObject, isNull, isValidJson, setValueIfNotNil,
+  isNonEmptyObject, isNull, isPureObject, isValidJson, setValueIfNotNil,
 } from '../utils/index';
 /*types*/
 import { TObject } from '../types';
@@ -269,6 +269,8 @@ class Request {
 
     if (this.actionPath) {
       this.validateActionData(this.actionPath, data);
+    } else if (this.resource === 'contactdata' && this.method === HttpMethods.Put) {
+      this.validateContactData(data);
     }
 
     if (!performAPICall) {
@@ -424,6 +426,38 @@ class Request {
 
     if (actionPath in validators) {
       validators[actionPath as keyof typeof validators](data);
+    }
+  }
+
+  private validateContactData(data: RequestData | Body) {
+    if (typeof data !== 'object' || isNull(data)) { // only if body is not JSON.stringified by user
+      return;
+    }
+
+    if (!isNonEmptyObject(data as UnknownRec)) {
+      throw new Error('"contactdata" PUT request expects request body to be not empty object');
+    }
+
+    if (!('Data' in data)) {
+      throw new Error('"contactdata" PUT request expects request body to contain a "Data" property');
+    }
+
+    const { Data } = data as UnknownRec;
+
+    if (!Array.isArray(Data)) {
+      throw new Error('"contactdata" PUT request expects "Data" property to be an array');
+    }
+
+    const isContactProperty = (property: unknown) => isPureObject(property)
+      && 'Name' in (property as UnknownRec)
+      && 'Value' in (property as UnknownRec);
+
+    if (!Data.every(isContactProperty)) {
+      throw new Error(
+        '"contactdata" PUT request expects "Data" to be an array of objects with "Name" and "Value" keys, '
+        + 'e.g. { Data: [{ Name: "first_name", Value: "John" }] }. '
+        + 'See https://dev.mailjet.com/email/reference/contacts/contact-properties/',
+      );
     }
   }
 }

--- a/test/unit/contactdata.test.ts
+++ b/test/unit/contactdata.test.ts
@@ -1,0 +1,152 @@
+import nock from 'nock';
+import { expect } from 'chai';
+import Mailjet, { Client, Request } from '../../lib/index';
+import { ClientParams } from '../../lib/client/Client';
+
+describe('Unit ContactData PUT request', () => {
+  const API_MAILJET_URL = `${Request.protocol}${Client.config.host}`;
+  const putUrl = `/${Client.config.version}/REST/contactdata/111`;
+  const params: ClientParams = {
+    apiKey: 'key',
+    apiSecret: 'secret',
+    config: {
+      version: 'v3',
+    },
+  };
+
+  const expectedResponse = {
+    Count: 1,
+    Data: [
+      {
+        ID: 1,
+        ContactID: 111,
+        Data: [
+          { Name: 'first_name', Value: 'John' },
+        ],
+      },
+    ],
+    Total: 1,
+  };
+
+  let mailjet: Mailjet;
+  let api: nock.Scope;
+
+  beforeEach(() => {
+    mailjet = new Mailjet(params);
+    api = nock(API_MAILJET_URL);
+  });
+
+  afterEach(() => {
+    api.done();
+  });
+
+  it('should work with Name/Value pairs for request data', async () => {
+    api.put(putUrl).reply(200, () => (expectedResponse));
+
+    const result = await mailjet
+      .put('contactdata', { version: 'v3' })
+      .id(111)
+      .request({
+        Data: [
+          { Name: 'first_name', Value: 'John' },
+        ],
+      });
+
+    expect(result.body).to.eql(expectedResponse);
+  });
+
+  it('should work with stringified body', async () => {
+    api.put(putUrl).reply(200, () => (expectedResponse));
+
+    const result = await mailjet
+      .put('contactdata', { version: 'v3' })
+      .id(111)
+      .request(JSON.stringify({
+        Data: [
+          { Name: 'first_name', Value: 'John' },
+        ],
+      }));
+
+    expect(result.body).to.eql(expectedResponse);
+  });
+
+  it('should throw an error if body is empty', async () => {
+    let error = null;
+    try {
+      await mailjet
+        .put('contactdata', { version: 'v3' })
+        .id(111)
+        .request({});
+    } catch (err) {
+      error = err;
+      expect(error).to.have.ownProperty('message', '"contactdata" PUT request expects request body to be not empty object');
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(error).to.be.not.null;
+    }
+  });
+
+  it('should throw an error if "Data" property is missing', async () => {
+    let error = null;
+    try {
+      await mailjet
+        .put('contactdata', { version: 'v3' })
+        .id(111)
+        .request({
+          firstName: 'John',
+        });
+    } catch (err) {
+      error = err;
+      expect(error).to.have.ownProperty('message', '"contactdata" PUT request expects request body to contain a "Data" property');
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(error).to.be.not.null;
+    }
+  });
+
+  it('should throw an error if "Data" is not an array', async () => {
+    let error = null;
+    try {
+      await mailjet
+        .put('contactdata', { version: 'v3' })
+        .id(111)
+        .request({
+          Data: { firstName: 'John' },
+        });
+    } catch (err) {
+      error = err;
+      expect(error).to.have.ownProperty('message', '"contactdata" PUT request expects "Data" property to be an array');
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(error).to.be.not.null;
+    }
+  });
+
+  it('should throw an error if "Data" entries use raw property keys instead of Name/Value pairs', async () => {
+    let error = null;
+    try {
+      await mailjet
+        .put('contactdata', { version: 'v3' })
+        .id(111)
+        .request({
+          // The most common mistake: sending property key/value pairs directly
+          // instead of { Name, Value } objects, which the Mailjet API rejects
+          // with a confusing "Invalid key name" error.
+          Data: [
+            { firstName: 'John', lastName: 'Smith' },
+          ],
+        });
+    } catch (err) {
+      error = err;
+      expect(error).to.have.ownProperty(
+        'message',
+        '"contactdata" PUT request expects "Data" to be an array of objects with "Name" and "Value" keys, '
+        + 'e.g. { Data: [{ Name: "first_name", Value: "John" }] }. '
+        + 'See https://dev.mailjet.com/email/reference/contacts/contact-properties/',
+      );
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      expect(error).to.be.not.null;
+    }
+  });
+});

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -1148,7 +1148,7 @@ describe('Unit Request', () => {
       it('should be skip request', async () => {
         const apiVersion = Client.config.version;
 
-        const resource = 'contactdata';
+        const resource = 'contact';
         const contactId = 2345234;
         const data = {
           Data: [
@@ -1209,7 +1209,7 @@ describe('Unit Request', () => {
       it('should be request by PUT/POST/DELETE methods', async () => {
         const apiVersion = Client.config.version;
 
-        const resource = 'contactdata';
+        const resource = 'contact';
         const contactId = 2345234;
         const data = {
           Data: [


### PR DESCRIPTION
…me errors

The Mailjet API requires PUT /contactdata/{id} requests to send "Data" as an array of { Name, Value } objects. The README example (and presumably copy-pasting users, per issue #293) instead used raw property key/value pairs (e.g. { first_name: "John" }), which the API silently rejects with a confusing "Invalid key name" 400 error.

- Add client-side validation for contactdata PUT requests, mirroring the existing managecontact action validator, so malformed payloads fail fast locally with a clear error instead of a cryptic server 400
- Fix the README contactdata example to use the correct Name/Value shape