### PR TITLE
test: Lock in unencoded email addresses for id() on contact/contactdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,6 +839,11 @@ request
         })
 ```
 
+> **Note:** \
+> For the `contact` and `contactdata` resources, `.id()` also accepts a contact's **email address**
+> instead of its numeric ID (e.g. `.id('user@example.com')`). Pass it as-is — the SDK does not
+> URL-encode it, matching what the Mailjet REST API expects.
+
 #### `PUT` Request
 
 Use the `put` method of the Mailjet client:

--- a/test/unit/request.test.ts
+++ b/test/unit/request.test.ts
@@ -446,6 +446,27 @@ describe('Unit Request', () => {
 
         expect(url).to.equal(`${Request.protocol}${Client.config.host}/v3/REST/template/123/detailcontent`);
       });
+
+      it('should not URL-encode email addresses passed to id() for contact/contactdata', () => {
+        const params: ClientParams = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+        };
+
+        const email = 'user+test@example.com';
+
+        ([
+          ['get', 'contact'],
+          ['get', 'contactdata'],
+          ['put', 'contactdata'],
+        ] as const).forEach(([method, resource]) => {
+          const request = new Client(params)[method](resource).id(email);
+          const url = request['buildFullUrl']();
+
+          expect(url).to.equal(`${Request.protocol}${Client.config.host}/v3/REST/${resource}/${email}`);
+          expect(url).to.not.include('%40');
+        });
+      });
     });
 
     describe('Request.buildSubPath()', () => {
@@ -1277,6 +1298,47 @@ describe('Unit Request', () => {
 
               expect(requestData.headers).to.haveOwnProperty('accept').that.includes('application/json');
             }),
+        );
+      });
+
+      it('should send email addresses passed to id() unencoded on the wire for contact/contactdata', async () => {
+        const apiVersion = Client.config.version;
+        const email = 'user@example.com';
+
+        const params: Required<Pick<ClientParams, 'apiKey' | 'apiSecret'>> = {
+          apiKey: 'key',
+          apiSecret: 'secret',
+        };
+
+        const client = new Client(params);
+
+        await Promise.all(
+          ([
+            [HttpMethods.Get, 'contact'],
+            [HttpMethods.Get, 'contactdata'],
+            [HttpMethods.Put, 'contactdata'],
+          ] as const).map(async ([method, resource]) => {
+            const path = `/${apiVersion}/REST/${resource}/${email}`;
+
+            let seenPath: string | undefined;
+            nock(API_MAILJET_URL)
+              .defaultReplyHeaders({
+                'Content-Type': 'application/json',
+              })[method](path)
+              .reply(200, function () {
+                seenPath = this.req.path;
+                return JSON.stringify({});
+              });
+
+            const data = method === HttpMethods.Put
+              ? { Data: [{ Name: 'first_name', Value: 'John' }] }
+              : undefined;
+
+            await client[method](resource).id(email).request(data);
+
+            expect(seenPath).to.equal(path);
+            expect(seenPath).to.not.include('%40');
+          }),
         );
       });
 


### PR DESCRIPTION
Issue #300 reported that .id() URL-encodes '@' to '%40' for contact/{email} and contactdata/{email}, causing Mailjet to reject the request with "Invalid action for resource". That was traced to the axios version pinned when 6.0.11 was released, which built request paths through the legacy Node url.parse() flow.

The already-upgraded axios in this repo (^1.18.1) builds paths via the WHATWG URL parser instead, which does not percent-encode '@' in a path per the URL Standard, so the bug no longer reproduces here. Verified directly against a raw HTTP server and via nock at the request()/buildFullUrl() level.

Add regression tests asserting id() preserves email addresses unencoded end-to-end for get/put on contact and contactdata, so a future axios/runtime change can't silently reintroduce this, and document the supported email-as-id usage in the README.