### PR TITLE
fix: Restore default export interop broken by UMD library.export: 'de…

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,6 +13,16 @@ class Mailjet extends Client {
   static Client = Client;
 }
 
+// The release build (see webpack/webpack.common.config.js) bundles this module with
+// UMD `library.export: 'default'`, so `require('node-mailjet')` resolves to this class
+// directly rather than to `{ default: Mailjet, ... }`. Consumers whose TS/bundler config
+// has no CJS/ESM default-export interop (e.g. esModuleInterop: false) compile
+// `import Mailjet from 'node-mailjet'` to `require('node-mailjet').default`, which would
+// otherwise be undefined. Self-referencing `.default` keeps that path working too,
+// mirroring how axios (`axios.default = axios`) solves the same problem.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(Mailjet as any).default = Mailjet;
+
 export * from './types/api';
 export { Client, Request, HttpMethods };
 export default Mailjet;

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import Mailjet, { Client, Request, HttpMethods } from '../../lib/index';
+
+describe('Unit Mailjet entrypoint', () => {
+  it('should be have static properties Client, Request and HttpMethods', () => {
+    expect(Mailjet).to.have.ownProperty('Client', Client);
+    expect(Mailjet).to.have.ownProperty('Request', Request);
+    expect(Mailjet).to.have.ownProperty('HttpMethods', HttpMethods);
+  });
+
+  it('should self-reference "default" so `import Mailjet from "node-mailjet"` works without CJS/ESM interop', () => {
+    // The release build bundles this module with webpack UMD `library.export: 'default'`,
+    // so `require('node-mailjet')` resolves to this class directly, not to
+    // `{ default: Mailjet, ... }`. Consumers compiling `import Mailjet from 'node-mailjet'`
+    // without esModuleInterop emit `require('node-mailjet').default`, which needs this
+    // self-reference to resolve to the class instead of `undefined`.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((Mailjet as any).default).to.equal(Mailjet);
+  });
+
+  it('should be callable via the self-referenced "default" the same way as the class itself', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const DefaultMailjet = (Mailjet as any).default;
+
+    expect(DefaultMailjet).itself.to.respondsTo('apiConnect');
+    expect(DefaultMailjet.apiConnect('key', 'secret')).to.be.an.instanceOf(Client);
+  });
+});


### PR DESCRIPTION
…fault'

The release build (webpack/webpack.common.config.js) bundles lib/index.ts with UMD `library.export: 'default'`, so require('node-mailjet') resolves directly to the Mailjet class, not to { default: Mailjet, ... }. The type declarations still promise `export default Mailjet`, so TypeScript happily compiles `import Mailjet from 'node-mailjet'`.

Under esModuleInterop: false (TypeScript's actual default, still common in Node backend configs) that import compiles to a bare `require('node-mailjet').default`, which is undefined since the bundle has no such property — causing "TypeError: Cannot read properties of undefined (reading 'apiConnect')" (#287). esModuleInterop: true masks the bug because its wrapper falls back to treating the whole module as the default when `__esModule` is unset.

Self-reference `.default` on the class, mirroring how axios (`axios.default = axios`) solves the identical UMD/interop mismatch. Verified against a real webpack-built bundle, consumed from a TypeScript project configured with esModuleInterop: false: reproduced the exact TypeError before the fix, resolved after.