### PR TITLE
fix: Add package.json exports map and ESM shim for named imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Next, require the module and initialize your [Mailjet][mailjet] client:
 const Mailjet = require('node-mailjet');
 ```
 
+The package also works with native ESM, including named imports:
+
+```javascript
+import Mailjet, { Client } from 'node-mailjet';
+```
+
 For `EMAIL API` and `SEND API`:
 ```js
 const mailjet = new Mailjet({

--- a/esm/mailjet.mjs
+++ b/esm/mailjet.mjs
@@ -1,0 +1,19 @@
+// Hand-written ESM entrypoint, copied into dist/mailjet.mjs by scripts/PreparePackage.js
+// (hence the "./mailjet.node.js" import path, valid once this file sits next to it).
+//
+// The Node/webpack CJS build (mailjet.node.js) is a UMD bundle, so its named exports
+// (Client, Request, HttpMethods) are not statically analyzable by cjs-module-lexer -
+// the mechanism native ESM uses to expose named exports from a CommonJS module. Without
+// this file, `import { Client } from 'node-mailjet'` fails under native ESM/ts-node/esm
+// with "SyntaxError: Named export 'Client' not found" (see issue #281), even though the
+// default import and `require()` both work fine.
+//
+// This file is real ESM syntax, so its `export` statements are always statically visible
+// to Node and to bundlers - no lexer heuristics involved.
+// eslint-disable-next-line import/no-unresolved, import/extensions
+import Mailjet from './mailjet.node.js';
+
+const { Client, Request, HttpMethods } = Mailjet;
+
+export default Mailjet;
+export { Client, Request, HttpMethods };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,14 @@
   "main": "./dist/mailjet.node.js",
   "browser": "./dist/mailjet.web.js",
   "types": "./dist/declarations/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/declarations/index.d.ts",
+      "import": "./dist/mailjet.mjs",
+      "require": "./dist/mailjet.node.js",
+      "default": "./dist/mailjet.node.js"
+    }
+  },
   "description": "Mailjet API client",
   "author": "Mailjet",
   "license": "MIT",

--- a/scripts/PreparePackage.js
+++ b/scripts/PreparePackage.js
@@ -13,6 +13,20 @@ function readJSONFile(filePath) {
   return JSON.parse(source);
 }
 
+function rewriteDistPaths(value) {
+  if (typeof value === 'string') {
+    return value.startsWith('./dist/') ? value.replace('./dist/', './') : value;
+  }
+  if (value !== null && typeof value === 'object') {
+    Object
+      .entries(value)
+      .forEach(([key, nestedValue]) => {
+        value[key] = rewriteDistPaths(nestedValue);
+      });
+  }
+  return value;
+}
+
 function changePackageData(packageData) {
   delete packageData.scripts;
   delete packageData.directories;
@@ -24,11 +38,7 @@ function changePackageData(packageData) {
   Object
     .entries(packageData)
     .forEach(([key, value]) => {
-      if (key === 'typescript') {
-        packageData[key].definition = value.definition.replace('./dist/', './');
-      } else if (typeof value === 'string' && value.startsWith('./dist/')) {
-        packageData[key] = value.replace('./dist/', './');
-      }
+      packageData[key] = rewriteDistPaths(value);
     });
 }
 
@@ -54,6 +64,7 @@ function main() {
   fs.copyFileSync(path.join(ROOT_DIR, 'LICENSE'), path.join(DIST_PATH, './LICENSE'));
   fs.copyFileSync(path.join(ROOT_DIR, 'README.md'), path.join(DIST_PATH, './README.md'));
   fs.copyFileSync(path.join(ROOT_DIR, 'CHANGELOG.md'), path.join(DIST_PATH, './CHANGELOG.md'));
+  fs.copyFileSync(path.join(ROOT_DIR, 'esm/mailjet.mjs'), path.join(DIST_PATH, './mailjet.mjs'));
 
   // package-lock.json
   childProcess.execSync('npm i --prefix ./dist/ --package-lock-only');


### PR DESCRIPTION
`import { Client } from 'node-mailjet'` failed under native ESM (e.g. node --loader=ts-node/esm) with "SyntaxError: Named export 'Client' not found" (#281). The Node CJS build is a webpack UMD bundle, so its named exports (Client, Request, HttpMethods) are attached at runtime and are not statically analyzable by cjs-module-lexer, the mechanism native ESM uses to expose named exports from a CommonJS module. Only the default export survived that detection.

Add esm/mailjet.mjs, a small hand-written ES module that imports the CJS build's default export and re-exports it plus each named member with real `export` syntax, which Node's ESM loader and bundlers read directly without any lexer heuristics. Wire it up via package.json's "exports" map ("import" -> the new shim, "require"/"default" -> the existing CJS bundle), and copy the shim into dist/ during build:prepublish alongside the other prepared files. Generalized PreparePackage.js's ./dist/ path rewriting to recurse into nested fields so it also rewrites the new "exports" map.

Verified against a real webpack-built bundle: reproduced the exact SyntaxError from the issue on an unpatched package layout, and confirmed both `import { Client }` and `import Mailjet from ...` resolve correctly, alongside the existing `require('node-mailjet')` path, on the patched layout.