### PR TITLE
docs: document batch sending partial-failure behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Check out all the resources and JS code examples in the official [Mailjet Docume
     - [Disable API call](#disable-api-call)
   - [TypeScript](#typescript)
     - [Send Email example](#send-email-example)
+    - [Batch sending & partial failures](#batch-sending--partial-failures)
     - [Send Message example](#send-message-example)
     - [Get Contact example](#get-contact-example)
     - [Our external Typings](#our-external-typings)
@@ -557,6 +558,73 @@ And `response` will have this shape:
     }
 }
 ```
+
+### Batch sending & partial failures
+
+The `Send API v3.1` lets you submit multiple emails in a single request via the `Messages` array _(this is often called "batch sending")_. \
+**Batch sending is not an atomic operation.** Each entry in `Messages` is validated and processed **independently**, so a single request can return a mix of successful and failed messages. A `2xx` HTTP response only means Mailjet accepted the request for processing — it does **not** mean every message in the batch was sent, and a message failure elsewhere in the batch does **not** stop the rest of the messages from being processed.
+
+Because of this, you should never assume the batch either "all succeeded" or "all failed". Instead, inspect the `Status` of **each** entry in `result.body.Messages`:
+- `Status: 'success'` — the message was accepted and is being delivered.
+- `Status: 'error'` — the message failed; details are available in that entry's `Errors` array _(`ErrorCode`, `ErrorMessage`, `ErrorIdentifier`)_.
+
+Set `AdvanceErrorHandling: true` on the request body to get one `Errors` entry per validation problem with machine-readable `ErrorCode`/`ErrorIdentifier` fields, which makes it easier to decide programmatically what happened and what, if anything, is safe to retry.
+
+```typescript
+import { Client, SendEmailV3_1, LibraryResponse } from 'node-mailjet';
+
+const mailjet = new Client({
+  apiKey: process.env.MJ_APIKEY_PUBLIC,
+  apiSecret: process.env.MJ_APIKEY_PRIVATE
+});
+
+(async () => {
+  const data: SendEmailV3_1.Body = {
+    Messages: [
+      {
+        From: { Email: 'pilot@test.com' },
+        To: [{ Email: 'passenger1@test.com' }],
+        Subject: 'Your flight plan (1)',
+        TextPart: 'This message is expected to succeed.',
+        CustomID: 'order-1001', // used below to correlate request <-> response
+      },
+      {
+        From: { Email: 'pilot@test.com' },
+        To: [{ Email: 'not-a-valid-address' }],
+        Subject: 'Your flight plan (2)',
+        TextPart: 'This message is expected to fail.',
+        CustomID: 'order-1002',
+      },
+    ],
+    AdvanceErrorHandling: true,
+  };
+
+  const result: LibraryResponse<SendEmailV3_1.Response> = await mailjet
+    .post('send', { version: 'v3.1' })
+    .request(data);
+
+  const succeeded = result.body.Messages.filter((message) => message.Status === 'success');
+  const failed = result.body.Messages.filter((message) => message.Status !== 'success');
+
+  // `failed` here does NOT mean the axios `.catch()`/promise rejection fired -
+  // the request itself succeeded, but some individual messages did not.
+})();
+```
+
+#### Retry guidance _(avoiding duplicate sends)_
+
+Because a batch can partially succeed, blindly retrying the whole request (or the whole `Messages` array) on any failure can **resend messages that already succeeded**, causing duplicate emails. To retry safely:
+
+1. Give every message a unique `CustomID` when you first send it, and keep a record of it (e.g. tied to your order/notification ID) before the request is made.
+2. On response, only collect the messages whose `Status` is `'error'` — never re-include messages whose `Status` was `'success'`.
+3. Use the failed message's `Errors[].StatusCode`/`ErrorCode` to decide if it's worth retrying:
+   - Validation-type errors (invalid recipient, malformed address, blocked domain, etc.) will fail again unless the message content itself is fixed — retrying unmodified is not useful.
+   - Transient/server-side errors _(`StatusCode >= 500`)_ may succeed on retry.
+4. When you do retry, resubmit only the failed messages, reusing the same `CustomID`, so you (and Mailjet's logs) can correlate the retry with the original attempt.
+5. Treat a request-level rejection (a thrown/rejected promise from `.request()`, e.g. network failure, auth failure, malformed payload) differently from a per-message `Status: 'error'` — the former means Mailjet never processed the batch at all, so the entire `Messages` array is safe to retry as-is.
+
+> See [`examples/node/src/batchSend.js`](https://github.com/mailjet/mailjet-apiv3-nodejs/tree/master/examples/node/src/batchSend.js) for a runnable example that sends a batch with one message designed to fail, and shows how to separate successes from failures and decide what to retry.
+
 ### Send Message Example
 ```typescript
 import * as Mailjet from 'node-mailjet'; // another possible importing option

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start:user": "node ./src/user.js",
     "start:sender": "node ./src/sender.js",
+    "start:batchsend": "node ./src/batchSend.js",
     "start:contact": "node ./src/contact.js",
     "start:eventcallbackurl": "node ./src/callback.js"
   },

--- a/examples/node/src/batchSend.js
+++ b/examples/node/src/batchSend.js
@@ -1,0 +1,84 @@
+const dotenv = require('dotenv');
+const Mailjet = require('node-mailjet');
+
+dotenv.config();
+
+const client = Mailjet
+	.apiConnect(process.env.MAILJET_API_KEY, process.env.MAILJET_API_SECRET)
+
+// Batch sending: the Send API v3.1 accepts multiple `Messages` in a single
+// request, but it does NOT treat the batch as an all-or-nothing operation.
+// Each message in `Messages` is processed independently, so some messages
+// can succeed while others fail (e.g. invalid recipient, blocked domain)
+// in the very same response. Always inspect `body.Messages[i].Status`
+// instead of assuming the whole request succeeded or failed as a unit.
+const data = {
+	Messages: [
+		{
+			From: { Email: 'pilot@test.com', Name: 'Mailjet Pilot' },
+			To: [{ Email: 'passenger1@test.com' }],
+			Subject: 'Your flight plan (1)',
+			TextPart: 'This message is expected to succeed.',
+			// CustomID lets you match each response entry back to the request
+			// that produced it, which is essential for safe retries below.
+			CustomID: 'order-1001',
+		},
+		{
+			From: { Email: 'pilot@test.com', Name: 'Mailjet Pilot' },
+			// Missing/invalid "To" is used here purely to illustrate a message
+			// that Mailjet will report as failed while the rest of the batch
+			// keeps processing.
+			To: [{ Email: 'not-a-valid-address' }],
+			Subject: 'Your flight plan (2)',
+			TextPart: 'This message is expected to fail.',
+			CustomID: 'order-1002',
+		},
+	],
+	// AdvanceErrorHandling: true gives one Errors entry per validation
+	// problem, with machine-readable ErrorCode/ErrorIdentifier fields,
+	// making it much easier to decide programmatically what is safe to retry.
+	AdvanceErrorHandling: true,
+};
+
+client
+	.post('send', { version: 'v3.1' })
+	.request(data)
+	.then(response => {
+		const { Messages } = response.body;
+
+		const succeeded = Messages.filter((message) => message.Status === 'success');
+		const failed = Messages.filter((message) => message.Status !== 'success');
+
+		console.log(`${succeeded.length}/${Messages.length} messages sent successfully`);
+
+		succeeded.forEach((message) => {
+			console.log(`  [sent] CustomID=${message.CustomID} -> ${message.To.map((to) => to.MessageID).join(', ')}`);
+		});
+
+		failed.forEach((message) => {
+			console.log(`  [failed] CustomID=${message.CustomID}`);
+			message.Errors.forEach((error) => {
+				console.log(`      ${error.ErrorCode}: ${error.ErrorMessage}`);
+			});
+		});
+
+		// Retry guidance: only resubmit the messages that actually failed, and
+		// only when the error is retryable (e.g. a transient server error, not
+		// an invalid recipient that will fail again). Reuse the same CustomID
+		// so failures can be reconciled by your own system/logs, and never
+		// resend a message whose Status was already "success" - doing so will
+		// duplicate the email.
+		const retryableFailures = failed.filter((message) => (
+			message.Errors.some((error) => error.StatusCode >= 500)
+		));
+
+		if (retryableFailures.length > 0) {
+			console.log(`${retryableFailures.length} message(s) failed with a potentially transient error and could be retried by CustomID.`);
+		}
+	})
+	.catch(err => {
+		// This branch only fires for request-level failures (network error,
+		// auth failure, malformed request, etc.) - it does NOT fire when
+		// individual messages inside a successfully-submitted batch fail.
+		console.log('error => ', err)
+	})

--- a/lib/types/api/SendEmail.ts
+++ b/lib/types/api/SendEmail.ts
@@ -119,11 +119,19 @@ export namespace SendEmailV3_1 {
     Variables?: Variables;
   }
 
+  // A batch request can contain a mix of successful and failed messages -
+  // the presence of `Error` results here does not mean the whole request
+  // failed, and `Success` does not mean every message in the batch was sent.
+  // Inspect `ResponseMessage.Status` for each entry in `Response.Messages`.
   export enum ResponseStatus {
     Success = 'success',
     Error = 'error',
   }
 
+  // Only present on messages whose `Status` is `Error`. `StatusCode` mirrors
+  // an HTTP status (e.g. >=500 generally indicates a transient/server-side
+  // failure that may be safe to retry, while 4xx generally indicates the
+  // message itself is invalid and retrying it unmodified will fail again).
   export interface ResponseError {
     ErrorIdentifier: string;
     ErrorCode: string;
@@ -160,6 +168,11 @@ export namespace SendEmailV3_1 {
   }
 
   // RESPONSE PART
+  // One entry per message submitted in `Body.Messages`, in the same order.
+  // Batch sending is NOT atomic: each message is validated and processed
+  // independently, so one message can fail (`Status: 'error'`) while the
+  // others in the same request succeed. Always check `Status`/`Errors` per
+  // message rather than relying on the request's HTTP status alone.
   export interface ResponseMessage {
     Status: ResponseStatus;
     Errors: ResponseError[];
@@ -169,6 +182,9 @@ export namespace SendEmailV3_1 {
     Bcc: ResponseEmailAddressTo[];
   }
 
+  // `Messages` can contain a mix of `'success'` and `'error'` entries - a
+  // 200 response does not guarantee every message was sent, and a batch
+  // containing failures does not mean the whole request was rejected.
   export type Response = {
     Messages: ResponseMessage[];
   }


### PR DESCRIPTION
Send API v3.1 processes each message in a batch independently, so a single request can return a mix of successes and failures. This was not documented anywhere, risking incorrect retry logic and duplicate sends. Add a README section on inspecting per-message Status/Errors and safe retry guidance, a runnable example, and clarifying JSDoc on the response types.